### PR TITLE
Fix 101 seq

### DIFF
--- a/20 Objects/AC27_101SEQ/AC27_101SEQ.ino
+++ b/20 Objects/AC27_101SEQ/AC27_101SEQ.ino
@@ -107,11 +107,8 @@ void setup() {
 //  ==================== start of loop() =======================
 void loop()
 {
-  int i, j, k;
-
   // deal with possible change of record/play mode
-  i = analogRead(3) > 511;
-  
+  int i = analogRead(3) > 511;
   
   // This determines if a record mode setting needs to change. NOTE:
   // most of the complexity comes because of the auto-turnoff at the

--- a/20 Objects/AC27_101SEQ/AC27_101SEQ.ino
+++ b/20 Objects/AC27_101SEQ/AC27_101SEQ.ino
@@ -174,7 +174,7 @@ void loop()
       
       // increment, and check for wrap-around
       currentPos++;
-      if ((currentPos >= loopEnd) || (currentPos >= loopMax)) {
+      if ((currentPos > loopEnd) || (currentPos > loopMax)) {
         currentPos = loopStart;
       }
      }


### PR DESCRIPTION
I noticed that the sequence played back in the 101 sequencer sketch was always one step shorter than the recorded one. Looks like an off-by-one error in the wraparound code. Also removed unused variables.